### PR TITLE
Remove namespace reference from SVG

### DIFF
--- a/utils/shortcodes.js
+++ b/utils/shortcodes.js
@@ -1,7 +1,7 @@
 module.exports = {
     icon: function (name) {
         return `<svg class="icon icon--${name}" role="img" aria-hidden="true" width="24" height="24">
-                    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-${name}"></use>
+                    <use xlink:href="#icon-${name}"></use>
                 </svg>`
     }
 }


### PR DESCRIPTION
I believe there’s no use for `xmlns:xlink` namespace on `<use>` element, especially in inline use case. Because when it’s inlined it’s not really XML anymore. Also `xlink` is [kinda obsolete](https://caniuse.com/#feat=mdn-svg_attributes_href) in many browsers, but I tend to keep it for compatibility reasons.