### PR TITLE
Migrate to Webpack5

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,30 +21,30 @@
   "author": "Max Böck",
   "license": "MIT",
   "dependencies": {
-    "@11ty/eleventy": "^0.11.1",
+    "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-img": "^0.8.2",
     "@11ty/eleventy-navigation": "^0.1.6",
-    "@11ty/eleventy-plugin-rss": "^1.0.9",
-    "@babel/core": "^7.11.4",
-    "@babel/plugin-transform-runtime": "^7.11.0",
-    "@babel/preset-env": "^7.11.0",
+    "@11ty/eleventy-plugin-rss": "^1.1.1",
+    "@babel/core": "^7.13.14",
+    "@babel/plugin-transform-runtime": "^7.13.10",
+    "@babel/preset-env": "^7.13.12",
     "babel-loader": "^8.2.2",
-    "clean-css": "^4.2.3",
-    "critical": "^2.0.3",
+    "clean-css": "^5.1.2",
+    "critical": "^3.0.0",
     "cssesc": "^3.0.0",
     "del-cli": "^3.0.1",
-    "focus-trap": "^5.1.0",
+    "focus-trap": "^6.3.0",
     "focus-visible": "^5.2.0",
     "html-minifier": "^4.0.0",
-    "luxon": "^1.25.0",
-    "markdown-it": "^12.0.2",
+    "luxon": "^1.26.0",
+    "markdown-it": "^12.0.4",
     "memfs": "^3.2.0",
     "node-sass": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "svg-sprite": "^1.5.0",
-    "webpack": "^4.44.1"
+    "webpack": "^5.28.0"
   },
   "devDependencies": {
-    "cross-env": "^7.0.2"
+    "cross-env": "^7.0.3"
   }
 }

--- a/src/assets/scripts/modules/nav.js
+++ b/src/assets/scripts/modules/nav.js
@@ -1,4 +1,4 @@
-import createFocusTrap from 'focus-trap'
+import { createFocusTrap } from 'focus-trap'
 
 const SELECTORS = {
     nav: '.js-nav',


### PR DESCRIPTION
Thank you for this awesome template!

This PR fixes a few deprecation issues related to migrating from webpack4 to webpack5. Webpack is only used to bundle JS assets, so only `__scripts.11ty.js` needs to be adapted.

The `memory-fs` dependency, used to bundle in RAM and then return the file contents as a string, has been deprecated. Instead, it is now recommended to use `memfs`.

Additionally, `compiler.resolvers.normal.fileSystem` and the somewhat hacky access to a compiled file's source through compilation stats, both have been deprecated and removed.

The fix to support webpack5 just reads the bundled file from memory (using mfs.readFile), and returns the content.